### PR TITLE
Add --toggle command-line flag and current time display

### DIFF
--- a/src/window/imp.rs
+++ b/src/window/imp.rs
@@ -50,6 +50,8 @@ pub struct MainWindow {
     pub gregorian_date: RefCell<String>,
     #[property(get, set)]
     pub hijri_date: RefCell<String>,
+    #[property(get, set)]
+    pub current_time: RefCell<String>,
 
     // Times
     #[property(get, set)]

--- a/src/window/mod.rs
+++ b/src/window/mod.rs
@@ -217,6 +217,11 @@ impl MainWindow {
         let imp = self.imp();
         let pref = &imp.preferences.borrow().preferences;
 
+        // Update current time
+        let now = Local::now();
+        let current_time_str = now.format("%H:%M").to_string();
+        self.set_current_time(current_time_str);
+
         let remaining_time = prayer::calculate_remaining_time(
             &imp.todays_prayers.borrow(),
             &imp.tomorrows_prayers.borrow(),

--- a/ui/MainWindow.blp
+++ b/ui/MainWindow.blp
@@ -13,6 +13,7 @@ template $MainWindow: Adw.ApplicationWindow {
   // Date
   gregorian-date: "-";
   hijri-date: "-";
+  current-time: "--:--";
   // Times
   time-fajr: "--:--";
   time-sunrise: "--:--";
@@ -85,6 +86,16 @@ template $MainWindow: Adw.ApplicationWindow {
                 ]
 
                 label: bind template.hijri-date;
+              }
+
+              Label {
+                margin-top: 7;
+
+                styles [
+                  "title-3",
+                ]
+
+                label: bind template.current-time;
               }
             }
 

--- a/ui/MainWindow.blp
+++ b/ui/MainWindow.blp
@@ -6,7 +6,7 @@ $RowPrayerTime dummy_row {}
 template $MainWindow: Adw.ApplicationWindow {
   title: "Vakt-i Salah";
   width-request: 280;
-  default-height: 460;
+  default-height: 510;
   hide-on-close: true;
   // District Info
   district-title: "";


### PR DESCRIPTION
This commit adds two new features:

1. Command-line toggle functionality:
   - Added --toggle flag to show/hide the window via command line
   - Useful for keyboard shortcuts and external scripts
   - Usage: flatpak run io.github.eminfedar.vaktisalah-gtk-rs --toggle
   - Modified src/main.rs to handle command-line arguments

2. Current time display:
   - Added live current time (HH:MM format) below the dates
   - Styled consistently with the rest of the UI
   - Updates every second
   - Automatically adapts to light/dark mode
   - Modified src/window/imp.rs, src/window/mod.rs, and ui/MainWindow.blp

<img width="402" height="582" alt="Screenshot from 2025-11-09 14 35 29" src="https://github.com/user-attachments/assets/04a9d5ad-47b7-4d80-b745-5f73ddc527d0" />